### PR TITLE
Re-org, cleanups, and add links to Recast and Esprima.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ## Transpilers
 
 * [Traceur compiler](https://github.com/google/traceur-compiler) - ES6 features > ES5/3. Includes classes, generators, promises, destructuring patterns, default parameters & more. 
-* Square [es6-module-transpiler](https://github.com/square/es6-module-transpiler) - ES6 modules to AMD or CJS
 * [es6ify](https://github.com/thlorenz/es6ify) - Traceur compiler wrapped as a Browserify v2 transform
 * [es6-transpiler](https://github.com/termi/es6-transpiler) - ES6 > ES5. Includes classes, destructuring, default parameters, spread
+* Square's [es6-module-transpiler](https://github.com/square/es6-module-transpiler) - ES6 modules to AMD or CJS
+* Square's [es6-arrow-function](https://github.com/square/es6-arrow-function) - ES6 arrow functions to ES5
 * Facebook's [regenerator](https://github.com/facebook/regenerator) - transform ES6 yield/generator functions to ES5
 * [defs](https://github.com/olov/defs) - ES6 block-scoped const and let variables to ES3 vars
-* [es6-arrow-function](https://github.com/square/es6-arrow-function) - ES6 arrow functions to ES5
 * [es6_module_transpiler-rails](https://github.com/dockyard/es6_module_transpiler-rails) - ES6 Modules in the Rails Asset Pipeline
 * [Some Sweet.js macros](https://github.com/jlongster/es6-macros) that compile from ES6 to ES5
 


### PR DESCRIPTION
- Moved let-er into "Other", since it supports a feature that was not accepted into ES6
- Added links to Esprima and Recast in "Other" section
- Small cleanups and re-org in the "Transpilers" section
  - Added a link to es-arrow-function
  - Clarified that es6ify is based on Traceur
