### PR TITLE
Add JetBrains IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 ## Editors
 
 * ES6 syntax highlighting for [Sublime Text and TextMate](https://github.com/Benvie/JavaScriptNext.tmLanguage)
-* ES6 syntax support in WebStorm and PhpStorm, compilation to ES5 with [Traceur file watcher](https://www.youtube.com/watch?v=jbfkcmxLLKY)
+* ES6 syntax support in [WebStorm](https://www.jetbrains.com/webstorm/) and [PhpStorm](https://www.jetbrains.com/phpstorm/), compilation to ES5 with [Traceur file watcher](https://www.youtube.com/watch?v=jbfkcmxLLKY)
 * DocPad [plugin](https://github.com/pflannery/docpad-plugin-traceur) for Traceur
 
 ## Parsers


### PR DESCRIPTION
WebStorm and PhpStorm supports ES6, and both have Traceur file watcher out of the box.
