### PR TITLE
change names and links for Babel plugins fromt 6to5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * esnext: [grunt-esnext](https://github.com/shinnn/grunt-esnext)
 
 ### Gulp Plugins
-* 6to5: [gulp-6to5](https://github.com/sindresorhus/gulp-6to5)
+* 6to5: [gulp-babel](https://github.com/babel/gulp-babel)
 * Traceur: [gulp-traceur](https://github.com/sindresorhus/gulp-traceur)
 * Regenerator: [gulp-regenerator](https://github.com/sindresorhus/gulp-regenerator)
 * ES6 Module Transpiler: [gulp-es6-module-transpiler](https://github.com/ryanseddon/gulp-es6-module-transpiler)
@@ -40,7 +40,7 @@
 * regexpu: [gulp-regexpu](https://github.com/mathiasbynens/gulp-regexpu)
 
 ### Broccoli Plugins
-* 6to5: [broccoli-6to5-transpiler](https://github.com/very-geek/broccoli-6to5-transpiler)
+* 6to5: [broccoli-babel-transpiler](https://github.com/babel/broccoli-babel-transpiler)
 * Traceur: [broccoli-traceur](https://github.com/sindresorhus/broccoli-traceur)
 * Regenerator: [broccoli-regenerator](https://github.com/sindresorhus/broccoli-regenerator)
 * ES6 Transpiler: [broccoli-transpiler](https://github.com/sindresorhus/broccoli-es6-transpiler)
@@ -67,14 +67,14 @@
 * Traceur: [gobble-es6-transpiler](https://github.com/gobblejs/gobble-es6-transpiler)
 
 ## Jade plugins
-* 6to5: [jade-6to5](https://github.com/apoxx/jade-6to5)
+* 6to5: [jade-babel](https://github.com/babel/jade-babel)
 * Traceur: [jade-traceur](https://www.npmjs.org/package/jade-traceur)
 
 ## Jest plugins
 * 6to5: [babel-jest](https://github.com/babel/babel-jest)
 
 ## Karma plugins
-* 6to5: [karma-6to5-preprocessor](https://github.com/shuhei/karma-6to5-preprocessor)
+* 6to5: [karma-babel-preprocessor](https://github.com/babel/karma-babel-preprocessor)
 * Traceur: [karma-traceur-preprocessor](https://github.com/karma-runner/karma-traceur-preprocessor)
 
 ## Sprockets plugins
@@ -156,6 +156,6 @@
 * [ES6 on node](http://h3manth.com/new/blog/2013/es6-on-nodejs/) - How to use ES6 features in node.js.
 * [es6-translate](https://github.com/calvinmetcalf/es6-translate) - Uses the ES6 loader hooks to load (node flavored) commonjs packages in ES6.
 * [Isparta](https://github.com/douglasduteil/isparta)
-* [6to5-node](http://6to5.github.io/usage.html#node-2) - Run node cli with ES6 transpiling using 6to5.
+* [6to5-node](http://babeljs.io/docs/usage/cli/#babel-node) - Run node cli with ES6 transpiling using 6to5.
 * [ES6 Lab setup](https://github.com/hemanth/es6-lab-setup) - A simple setup for transpiling ES6 to ES5 using `6to5` or `traceur` with `gulp` and `jasmine` support.
 * [TypeScript](http://www.typescriptlang.org/) - A superset of ECMAScript with strict typing that aims to align with ES6

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Build-time transpilation
 
 ### Grunt Tasks
-* 6to5: [grunt-6to5](https://github.com/sindresorhus/grunt-6to5) - Turn ES6+ code into vanilla ES5 with no runtime
+* Babel: [grunt-babel](https://github.com/babel/grunt-babel) - Turn ES6+ code into vanilla ES5 with no runtime
 * Traceur: [grunt-traceur](https://github.com/aaronfrost/grunt-traceur) ES6 > ES5 transpilation, [grunt-traceur-build](https://github.com/tarruda/grunt-traceur-build)
 * ES6 Module Transpiler: [grunt-es6-module-transpiler](https://github.com/joefiorini/grunt-es6-module-transpiler)
 * Regenerator: [grunt-regenerator](https://github.com/sindresorhus/grunt-regenerator) - ES6 generator functions to ES5
@@ -30,7 +30,7 @@
 * esnext: [grunt-esnext](https://github.com/shinnn/grunt-esnext)
 
 ### Gulp Plugins
-* 6to5: [gulp-babel](https://github.com/babel/gulp-babel)
+* Babel: [gulp-babel](https://github.com/babel/gulp-babel)
 * Traceur: [gulp-traceur](https://github.com/sindresorhus/gulp-traceur)
 * Regenerator: [gulp-regenerator](https://github.com/sindresorhus/gulp-regenerator)
 * ES6 Module Transpiler: [gulp-es6-module-transpiler](https://github.com/ryanseddon/gulp-es6-module-transpiler)
@@ -40,7 +40,7 @@
 * regexpu: [gulp-regexpu](https://github.com/mathiasbynens/gulp-regexpu)
 
 ### Broccoli Plugins
-* 6to5: [broccoli-babel-transpiler](https://github.com/babel/broccoli-babel-transpiler)
+* Babel: [broccoli-babel-transpiler](https://github.com/babel/broccoli-babel-transpiler)
 * Traceur: [broccoli-traceur](https://github.com/sindresorhus/broccoli-traceur)
 * Regenerator: [broccoli-regenerator](https://github.com/sindresorhus/broccoli-regenerator)
 * ES6 Transpiler: [broccoli-transpiler](https://github.com/sindresorhus/broccoli-es6-transpiler)
@@ -49,36 +49,36 @@
 * ES6 fat arrow transpiler: [broccoli-es6-arrow](https://github.com/hemanth/broccoli-es6-arrow.git)
 
 ### Brunch Plugins
-* 6to5: [babel-brunch](https://github.com/babel/babel-brunch)
+* Babel: [babel-brunch](https://github.com/babel/babel-brunch)
 * ES6 Module Transpiler: [es6-module-transpiler-brunch](https://github.com/gcollazo/es6-module-transpiler-brunch)
 
 ## Webpack plugins
-* 6to5: [babel-loader](https://github.com/babel/babel-loader)
+* Babel: [babel-loader](https://github.com/babel/babel-loader)
 * Traceur: [webpack-traceur-loader](https://github.com/ndhoule/webpack-traceur-loader)
 
 ## Duo plugins
-* 6to5: [duo-babel](https://github.com/babel/duo-babel)
+* Babel: [duo-babel](https://github.com/babel/duo-babel)
 
 ## Connect plugins
-* 6to5: [babel-connect](https://github.com/babel/babel-connect)
+* Babel: [babel-connect](https://github.com/babel/babel-connect)
 
 ## Gobble plugins
-* 6to5: [gobble-babel](https://github.com/babel/gobble-babel)
+* Babel: [gobble-babel](https://github.com/babel/gobble-babel)
 * Traceur: [gobble-es6-transpiler](https://github.com/gobblejs/gobble-es6-transpiler)
 
 ## Jade plugins
-* 6to5: [jade-babel](https://github.com/babel/jade-babel)
+* Babel: [jade-babel](https://github.com/babel/jade-babel)
 * Traceur: [jade-traceur](https://www.npmjs.org/package/jade-traceur)
 
 ## Jest plugins
-* 6to5: [babel-jest](https://github.com/babel/babel-jest)
+* Babel: [babel-jest](https://github.com/babel/babel-jest)
 
 ## Karma plugins
-* 6to5: [karma-babel-preprocessor](https://github.com/babel/karma-babel-preprocessor)
+* Babel: [karma-babel-preprocessor](https://github.com/babel/karma-babel-preprocessor)
 * Traceur: [karma-traceur-preprocessor](https://github.com/karma-runner/karma-traceur-preprocessor)
 
 ## Sprockets plugins
-* 6to5: [sprockets-es6](https://github.com/josh/sprockets-es6)
+* Babel: [sprockets-es6](https://github.com/josh/sprockets-es6)
 * Traceur: [sprockets-traceur](https://github.com/gunpowderlabs/sprockets-traceur)
 
 ## Module Loaders
@@ -156,6 +156,6 @@
 * [ES6 on node](http://h3manth.com/new/blog/2013/es6-on-nodejs/) - How to use ES6 features in node.js.
 * [es6-translate](https://github.com/calvinmetcalf/es6-translate) - Uses the ES6 loader hooks to load (node flavored) commonjs packages in ES6.
 * [Isparta](https://github.com/douglasduteil/isparta)
-* [6to5-node](http://babeljs.io/docs/usage/cli/#babel-node) - Run node cli with ES6 transpiling using 6to5.
+* [babel-node](http://babeljs.io/docs/usage/cli/#babel-node) - Run node cli with ES6 transpiling using Babel.
 * [ES6 Lab setup](https://github.com/hemanth/es6-lab-setup) - A simple setup for transpiling ES6 to ES5 using `6to5` or `traceur` with `gulp` and `jasmine` support.
 * [TypeScript](http://www.typescriptlang.org/) - A superset of ECMAScript with strict typing that aims to align with ES6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * [Babel](https://github.com/babel/babel) - Turn ES6+ code into vanilla ES5 with no runtime
 * [Traceur compiler](https://github.com/google/traceur-compiler) - ES6 features > ES5. Includes classes, generators, promises, destructuring patterns, default parameters & more.
 * [es6ify](https://github.com/thlorenz/es6ify) - Traceur compiler wrapped as a [Browserify](http://browserify.org/) v2 transform
-* [6to5ify](https://github.com/6to5/6to5ify) - 6to5 transpiler wrapped as a [Browserify](http://browserify.org/) transform
+* [babelify](https://github.com/babel/babelify) - Babel transpiler wrapped as a [Browserify](http://browserify.org/) transform
 * [es6-transpiler](https://github.com/termi/es6-transpiler) - ES6 > ES5. Includes classes, destructuring, default parameters, spread
 * Square's [es6-module-transpiler](https://github.com/square/es6-module-transpiler) - ES6 modules to AMD or CJS
 * Square's [esnext](https://github.com/square/esnext) - next generation JavaScript to today's JavaScript transformer now a part of 6to5.
@@ -49,21 +49,21 @@
 * ES6 fat arrow transpiler: [broccoli-es6-arrow](https://github.com/hemanth/broccoli-es6-arrow.git)
 
 ### Brunch Plugins
-* 6to5: [6to5-brunch](https://github.com/6to5/6to5-brunch)
+* 6to5: [babel-brunch](https://github.com/babel/babel-brunch)
 * ES6 Module Transpiler: [es6-module-transpiler-brunch](https://github.com/gcollazo/es6-module-transpiler-brunch)
 
 ## Webpack plugins
-* 6to5: [6to5-loader](https://github.com/6to5/6to5-loader)
+* 6to5: [babel-loader](https://github.com/babel/babel-loader)
 * Traceur: [webpack-traceur-loader](https://github.com/ndhoule/webpack-traceur-loader)
 
 ## Duo plugins
-* 6to5: [duo-6to5](https://github.com/6to5/duo-6to5)
+* 6to5: [duo-babel](https://github.com/babel/duo-babel)
 
 ## Connect plugins
-* 6to5: [6to5-connect](https://github.com/6to5/connect)
+* 6to5: [babel-connect](https://github.com/babel/babel-connect)
 
 ## Gobble plugins
-* 6to5: [gobble-6to5](https://github.com/6to5/gobble-6to5)
+* 6to5: [gobble-babel](https://github.com/babel/gobble-babel)
 * Traceur: [gobble-es6-transpiler](https://github.com/gobblejs/gobble-es6-transpiler)
 
 ## Jade plugins
@@ -71,7 +71,7 @@
 * Traceur: [jade-traceur](https://www.npmjs.org/package/jade-traceur)
 
 ## Jest plugins
-* 6to5: [6to5-jest](https://github.com/6to5/jest)
+* 6to5: [babel-jest](https://github.com/babel/babel-jest)
 
 ## Karma plugins
 * 6to5: [karma-6to5-preprocessor](https://github.com/shuhei/karma-6to5-preprocessor)


### PR DESCRIPTION
These are only the plugins that were originall at github.com/6to5