### PR TITLE
docs(Webpack plugins): update traceur-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 ## Webpack plugins
 * Babel: [babel-loader](https://github.com/babel/babel-loader)
-* Traceur: [webpack-traceur-loader](https://github.com/ndhoule/webpack-traceur-loader)
+* Traceur: [traceur-compiler-loader](https://github.com/gdi2290/traceur-compiler-loader)
 
 ## Duo plugins
 * Babel: [duo-babel](https://github.com/babel/duo-babel)


### PR DESCRIPTION
previous version is years behind running on version 0.5x while this one is 0.8x