### PR TITLE
Boilerplate Babel ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 
 ## Boilerplates
 * [es6-boilerplate](https://github.com/davidjnelson/es6-boilerplate) - Tooling to allow the community to use es6 now via traceur in conjunction with amd and browser global modules, with source maps, concatenation, minification, compression, and unit testing in real browsers.
+* [es6-babel-browserify-boilerplate](https://github.com/thoughtram/es6-babel-browserify-boilerplate) - An opinionated boilerplate that uses babel to allow for es6 features and uses browserify for file bundleing.
 
 ## Code generation
 


### PR DESCRIPTION
boilerplate that uses babel to allow for es6.