### PR TITLE
Adds es6-jspm-gulp-boilerplate to boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 
 ## Boilerplates
 * [es6-boilerplate](https://github.com/davidjnelson/es6-boilerplate) - Tooling to allow the community to use es6 now via traceur in conjunction with amd and browser global modules, with source maps, concatenation, minification, compression, and unit testing in real browsers.
+* [es6-jspm-gulp-boilerplate](https://github.com/alexweber/es6-jspm-gulp-boilerplate) - Tooling to allow the community to use es6 now via babel in conjunction jspm, with source maps, concatenation, minification, compression, and unit testing in real browsers using es6.
 
 ## Code generation
 


### PR DESCRIPTION
Adds [es6-jspm-gulp-boilerplate](https://github.com/alexweber/es6-jspm-gulp-boilerplate) to the list of boilerplates.  Disclaimer: I'm the maintainer.

Feel free to add or not, thanks! :)