### PR TITLE
Update information on Esprima

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@
 
 ## Parsers
 
-* [Esprima Harmony branch](https://github.com/ariya/esprima/tree/harmony) - Experimental branch of the Esprima parser which can parse ES6 features to [SpiderMonkey AST](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API) format.
+* [Esprima](http://esprima.org) - JavaScript parser supporting ES6, parses to [ESTree AST format](https://github.com/estree/estree)
 * [Acorn](https://github.com/ternjs/acorn) - A small, fast, JavaScript-based JavaScript parser with ES6 support, parses to [SpiderMonkey AST](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API) format.
 * [esparse](https://github.com/zenparsing/esparse) - ES6 parser written in ES6.
 * [Traceur compiler](https://github.com/google/traceur-compiler) also has built-in parser available under `traceur.syntax.Parser`.


### PR DESCRIPTION
The latest version of Esprima has supported ES6/ES2015 features for a while.
Harmony branch is long gone, unsupported, and outdated. 
