### PR TITLE
Fix broken url for typescript-brunch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ### Brunch Plugins
 * Babel: [babel-brunch](https://github.com/babel/babel-brunch)
 * ES6 Module Transpiler: [es6-module-transpiler-brunch](https://github.com/gcollazo/es6-module-transpiler-brunch)
-* TypeScript: [typescript-brunch](https://github.com/joshheyse/typescript-brunch)
+* TypeScript: [brunch-typescript](https://github.com/baptistedonaux/brunch-typescript)
 
 ## Webpack plugins
 * Babel: [babel-loader](https://github.com/babel/babel-loader)


### PR DESCRIPTION
Turns him:
<img width="256" alt="screen shot 2017-01-14 at 03 15 45" src="https://cloud.githubusercontent.com/assets/1521229/21950909/2a463698-da08-11e6-8448-89600352b2fa.png">

into him:

<img width="258" alt="screen shot 2017-01-14 at 03 17 01" src="https://cloud.githubusercontent.com/assets/1521229/21950913/2f39f554-da08-11e6-8a88-a04e886d2284.png">
